### PR TITLE
Create CacheAsyncImage

### DIFF
--- a/CacheAsyncImage
+++ b/CacheAsyncImage
@@ -1,0 +1,91 @@
+
+struct CacheAsyncImage<Content>: View where Content: View {
+
+    private let url: String
+    private let scale: CGFloat
+    private let transaction: Transaction
+    private let content: (AsyncImagePhase) -> Content
+
+    init(
+        url: String,
+        scale: CGFloat = 1.0,
+        transaction: Transaction = Transaction(),
+        @ViewBuilder content: @escaping (AsyncImagePhase) -> Content
+    ) {
+        self.url = url
+        self.scale = scale
+        self.transaction = transaction
+        self.content = content
+    }
+
+    var body: some View {
+
+        if let cached = ImageCache[url] {
+            let _ = print("cached \(url)")
+            content(.success(cached))
+        } else {
+            let _ = print("request \(url)")
+            if let url = URL(string: url){
+                AsyncImage(
+                    url: url,
+                    scale: scale,
+                    transaction: transaction
+                ) { phase in
+                    cacheAndRender(phase: phase)
+                }
+            }
+        }
+    }
+
+    func cacheAndRender(phase: AsyncImagePhase) -> some View {
+        if case .success(let image) = phase {
+            ImageCache[url] = image
+        }
+
+        return content(phase)
+    }
+}
+
+struct CacheAsyncImage_Previews: PreviewProvider {
+    static var previews: some View {
+        CacheAsyncImage(
+            url: "https://seanallen-course-backend.herokuapp.com/images/appetizers/buffalo-chicken-bites.jpg"
+        ) { phase in
+            switch phase {
+            case .empty:
+                ProgressView()
+            case .success(let image):
+                image
+            case .failure(let error):
+                ErrorView(error: error)
+            @unknown default:
+                fatalError()
+            }
+        }
+    }
+}
+
+
+fileprivate class ImageCache {
+    static private var cache: [String: Image] = [:]
+
+    static subscript(url: String) -> Image? {
+        get {
+            ImageCache.cache[url]
+        }
+        set {
+            ImageCache.cache[url] = newValue
+        }
+    }
+}
+
+import SwiftUI
+
+struct ErrorView: View {
+    let error: Error
+
+    var body: some View {
+        print(error)
+        return Text("❌ **Error**").font(.system(size: 60))
+    }
+}


### PR DESCRIPTION
I suggest you try this instead of 


RemoteImage(image: imageLoader.image)
            .onAppear() {
                imageLoader.loadImage(fromURL: imageURL)
           }


use this  syntax: 
CacheAsyncImage(url: imageURL) { phase in
            switch phase {
            case .empty:
                ProgressView(label: {
                    Text("Loading")
                        .font(.caption)
                })
            case .success(let image):
                image.resizable()
            case .failure(let error):
                ErrorView(error: error)
            @unknown default:
                Image("foodPlaceHolder").resizable()
            }
        }

then you will see Memory is more optimized.